### PR TITLE
allow more VAPs

### DIFF
--- a/target_firmware/wlan/include/wlan_hdr.h
+++ b/target_firmware/wlan/include/wlan_hdr.h
@@ -96,8 +96,8 @@ struct ieee80211com_target {
 	a_uint8_t     pad;
 };
 
-#define ATH_NODE_MAX 8       /* max no. of nodes */
-#define ATH_VAP_MAX  2       /* max no. of vaps */
+#define ATH_NODE_MAX 16       /* max no. of nodes */
+#define ATH_VAP_MAX  8       /* max no. of vaps */
 
 #define VAP_TARGET_SIZE 12
 


### PR DESCRIPTION
Allow creating more virtual interfaces. Currently driver/fw is stable running 3 AP interfaces with one client connected to each. Max. no of interfaces a single client could connect to was 7. 

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>